### PR TITLE
handle NPE thrown when both lpi/mpi results are rejected

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyareg/api/PersonMergeService.java
+++ b/api/src/main/java/org/openmrs/module/kenyareg/api/PersonMergeService.java
@@ -23,236 +23,244 @@ import org.springframework.stereotype.Service;
 import ke.go.moh.oec.Person;
 import ke.go.moh.oec.PersonIdentifier;
 import ke.go.moh.oec.PersonIdentifier.Type;
+import org.springframework.util.CollectionUtils;
 
 @Service("personMergeService")
 public class PersonMergeService {
 
-	private Logger log = LoggerFactory.getLogger(PersonMergeService.class);
+    private Logger log = LoggerFactory.getLogger(PersonMergeService.class);
 
-	@Autowired(required = true)
-	@Qualifier("patientService")
-	PatientService patientService;
-	private final String[] properties = new String[]
-			{
-				"lastName", "firstName", "middleName", "otherName",
-				"clanName", "sex", "birthdate", "mothersFirstName",
-				"mothersMiddleName", "mothersLastName", "fathersFirstName",
-				"fathersMiddleName", "fathersLastName",
-				"villageName", "maritalStatus"
-			};
+    @Autowired(required = true)
+    @Qualifier("patientService")
+    PatientService patientService;
+    private final String[] properties = new String[]
+            {
+                    "lastName", "firstName", "middleName", "otherName",
+                    "clanName", "sex", "birthdate", "mothersFirstName",
+                    "mothersMiddleName", "mothersLastName", "fathersFirstName",
+                    "fathersMiddleName", "fathersLastName",
+                    "villageName", "maritalStatus"
+            };
 
-	public void mergePatientIdentifiers(Patient patient, List<PersonIdentifier> identifiers, Location location) {
-		assert patient != null;
-		assert identifiers != null;
-		for (PersonIdentifier identifier: identifiers) {
-			if (matchesIdentifierInOmrs(identifier.getIdentifierType().toString())) {
-				updateOmrsIdentifier(patient, identifier.getIdentifier(), identifier.getIdentifierType().toString(), location);
-			}
-		}
-	}
+    public void mergePatientIdentifiers(Patient patient, List<PersonIdentifier> identifiers, Location location) {
+        assert patient != null;
+        assert identifiers != null;
+        for (PersonIdentifier identifier : identifiers) {
+            if (matchesIdentifierInOmrs(identifier.getIdentifierType().toString())) {
+                updateOmrsIdentifier(patient, identifier.getIdentifier(), identifier.getIdentifierType().toString(), location);
+            }
+        }
+    }
 
-	private boolean matchesIdentifierInOmrs(String identifierName) {
-		List<PatientIdentifierType> availableOmrsIdentifierTypes = patientService.getAllPatientIdentifierTypes();
+    private boolean matchesIdentifierInOmrs(String identifierName) {
+        List<PatientIdentifierType> availableOmrsIdentifierTypes = patientService.getAllPatientIdentifierTypes();
 
-		for (PatientIdentifierType identifierType : availableOmrsIdentifierTypes) {
-			if (identifierType.getName().equalsIgnoreCase(identifierName)) {
-				return true;
-			}
-		}
-		return false;
-	}
+        for (PatientIdentifierType identifierType : availableOmrsIdentifierTypes) {
+            if (identifierType.getName().equalsIgnoreCase(identifierName)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	private void updateOmrsIdentifier(Patient omrsPerson, String identifier, String identifierType, Location location) {
-		PatientIdentifierType patientIdentifierType = patientService.getPatientIdentifierTypeByName(identifierType);
-		PatientIdentifier patientIdentifier = new PatientIdentifier(identifier, patientIdentifierType, location);
-		boolean identifierSet = false;
-		for (PatientIdentifier existingIdentifier : omrsPerson.getIdentifiers()) {
-			if (existingIdentifier.getIdentifierType().getName().equalsIgnoreCase(identifierType)
-					&& !existingIdentifier.equalsContent(patientIdentifier)) {
-				existingIdentifier.setIdentifier(identifier);
-				identifierSet = true;
-				break;
-			}
-		}
-		if (!identifierSet) {
-			omrsPerson.addIdentifier(patientIdentifier);
-		}
-	}
+    private void updateOmrsIdentifier(Patient omrsPerson, String identifier, String identifierType, Location location) {
+        PatientIdentifierType patientIdentifierType = patientService.getPatientIdentifierTypeByName(identifierType);
+        PatientIdentifier patientIdentifier = new PatientIdentifier(identifier, patientIdentifierType, location);
+        boolean identifierSet = false;
+        for (PatientIdentifier existingIdentifier : omrsPerson.getIdentifiers()) {
+            if (existingIdentifier.getIdentifierType().getName().equalsIgnoreCase(identifierType)
+                    && !existingIdentifier.equalsContent(patientIdentifier)) {
+                existingIdentifier.setIdentifier(identifier);
+                identifierSet = true;
+                break;
+            }
+        }
+        if (!identifierSet) {
+            omrsPerson.addIdentifier(patientIdentifier);
+        }
+    }
 
-	public org.openmrs.Person mergePerson(org.openmrs.Person fromOmrs, Person fromMpi) {
-		if (fromOmrs == null) {
-			fromOmrs = new org.openmrs.Person();
-			fromOmrs.setUuid(fromMpi.getPersonGuid());
-		}
-		fromOmrs.setGender(fromMpi.getSex() == null ? "M" : fromMpi.getSex().toString());
-		fromOmrs.setBirthdate(fromMpi.getBirthdate());
-		fromOmrs.setDeathDate(fromMpi.getDeathdate());
+    public org.openmrs.Person mergePerson(org.openmrs.Person fromOmrs, Person fromMpi) {
+        if (fromOmrs == null) {
+            fromOmrs = new org.openmrs.Person();
+            fromOmrs.setUuid(fromMpi.getPersonGuid());
+        }
+        fromOmrs.setGender(fromMpi.getSex() == null ? "M" : fromMpi.getSex().toString());
+        fromOmrs.setBirthdate(fromMpi.getBirthdate());
+        fromOmrs.setDeathDate(fromMpi.getDeathdate());
 
-		PersonName personName = fromOmrs.getPersonName();
-		if (personName == null) {
-			personName = new PersonName();
-			personName.setPerson(fromOmrs);
-		}
-		personName.setGivenName(fromMpi.getFirstName());
-		personName.setMiddleName(fromMpi.getMiddleName());
-		personName.setFamilyName(fromMpi.getLastName());
-		fromOmrs.addName(personName);
+        PersonName personName = fromOmrs.getPersonName();
+        if (personName == null) {
+            personName = new PersonName();
+            personName.setPerson(fromOmrs);
+        }
+        personName.setGivenName(fromMpi.getFirstName());
+        personName.setMiddleName(fromMpi.getMiddleName());
+        personName.setFamilyName(fromMpi.getLastName());
+        fromOmrs.addName(personName);
 
-		return fromOmrs;
-	}
+        return fromOmrs;
+    }
 
-	public Map<String, Object> getLpiMpiMergedProperties(Person fromLpi, Person fromMpi) {
-		if (fromLpi == null && fromMpi == null) {
-			return Collections.emptyMap();
-		}
-		Map<String, Object> mergedProperties = new HashMap<String, Object>();
-		for (String property : properties) {
-			String methodName = "get" + StringUtils.capitalize(property);
-			try {
-				Method method = Person.class.getMethod(methodName);
-				Object lpiValue = method.invoke(fromLpi);
-				Object mpiValue = method.invoke(fromMpi);
-				if (lpiValue == null && mpiValue == null) {
-					continue;
-				}
-				if (lpiValue instanceof String || mpiValue instanceof String) {
-					if (lpiValue == null) {
-						mergedProperties.put(property, mpiValue.toString());
-					} else if (mpiValue == null) {
-						mergedProperties.put(property, lpiValue.toString());
-					} else if (StringUtils.equalsIgnoreCase(lpiValue.toString(), mpiValue.toString())) {
-						mergedProperties.put(property, lpiValue.toString());
-					}
-				} else if (lpiValue instanceof Date || mpiValue instanceof Date) {
-					Date mpiDate = null;
-					Date lpiDate = null;
-					if (lpiValue == null) {
-						mpiDate = (Date)mpiValue;
-						mergedProperties.put(property, mpiDate);
-						continue;
-					} else if (mpiValue == null) {
-						lpiDate = (Date)lpiValue;
-						mergedProperties.put(property, lpiDate);
-						continue;
-					}
-					lpiDate = (Date)lpiValue;
-					mpiDate = (Date)mpiValue;
-					if (lpiDate.compareTo(mpiDate) == 0) {
-						mergedProperties.put(property, lpiDate);
-					}
-				} else {
-					if (lpiValue == null) {
-						mergedProperties.put(property, mpiValue);
-					} else if (mpiValue == null) {
-						mergedProperties.put(property, lpiValue.toString());
-					} else if (lpiValue == mpiValue) {
-						mergedProperties.put(property, lpiValue.toString());
-					}
-				}
-			} catch (Exception e) {
-				log.warn(e.getMessage());
-			}
-		}
-		return mergedProperties;
-	}
+    public Map<String, Object> getLpiMpiMergedProperties(Person fromLpi, Person fromMpi) {
+        if (fromLpi == null && fromMpi == null) {
+            return Collections.emptyMap();
+        }
+        Map<String, Object> mergedProperties = new HashMap<String, Object>();
+        for (String property : properties) {
+            String methodName = "get" + StringUtils.capitalize(property);
+            try {
+                Method method = Person.class.getMethod(methodName);
+                Object lpiValue = method.invoke(fromLpi);
+                Object mpiValue = method.invoke(fromMpi);
+                if (lpiValue == null && mpiValue == null) {
+                    continue;
+                }
+                if (lpiValue instanceof String || mpiValue instanceof String) {
+                    if (lpiValue == null) {
+                        mergedProperties.put(property, mpiValue.toString());
+                    } else if (mpiValue == null) {
+                        mergedProperties.put(property, lpiValue.toString());
+                    } else if (StringUtils.equalsIgnoreCase(lpiValue.toString(), mpiValue.toString())) {
+                        mergedProperties.put(property, lpiValue.toString());
+                    }
+                } else if (lpiValue instanceof Date || mpiValue instanceof Date) {
+                    Date mpiDate = null;
+                    Date lpiDate = null;
+                    if (lpiValue == null) {
+                        mpiDate = (Date) mpiValue;
+                        mergedProperties.put(property, mpiDate);
+                        continue;
+                    } else if (mpiValue == null) {
+                        lpiDate = (Date) lpiValue;
+                        mergedProperties.put(property, lpiDate);
+                        continue;
+                    }
+                    lpiDate = (Date) lpiValue;
+                    mpiDate = (Date) mpiValue;
+                    if (lpiDate.compareTo(mpiDate) == 0) {
+                        mergedProperties.put(property, lpiDate);
+                    }
+                } else {
+                    if (lpiValue == null) {
+                        mergedProperties.put(property, mpiValue);
+                    } else if (mpiValue == null) {
+                        mergedProperties.put(property, lpiValue.toString());
+                    } else if (lpiValue == mpiValue) {
+                        mergedProperties.put(property, lpiValue.toString());
+                    }
+                }
+            } catch (Exception e) {
+                log.warn(e.getMessage());
+            }
+        }
+        return mergedProperties;
+    }
 
-	public Map<String, Map<String, Object>> getLpiMpiConflictingProperties(Person fromLpi, Person fromMpi) {
-		if (fromLpi == null && fromMpi == null) {
-			return Collections.emptyMap();
-		}
-		Map<String, Map<String, Object>> conflictingProperties = new HashMap<String, Map<String, Object>>();
-		for (String property : properties) {
-			String methodName = "get" + StringUtils.capitalize(property);
-			try {
-				Method method = Person.class.getMethod(methodName);
-				Object lpiValue = method.invoke(fromLpi);
-				Object mpiValue = method.invoke(fromMpi);
-				if (lpiValue == null || mpiValue == null) {
-					continue;
-				}
-				if (lpiValue instanceof String || mpiValue instanceof String) {
-					if (!StringUtils.equalsIgnoreCase(lpiValue.toString(), mpiValue.toString())) {
-						Map<String, Object> conflictedProperty = new HashMap<String, Object>();
-						conflictedProperty.put("lpi", lpiValue.toString());
-						conflictedProperty.put("mpi", mpiValue.toString());
-						conflictingProperties.put(property, conflictedProperty);
-					}
-				} else if (lpiValue instanceof Date || mpiValue instanceof Date) {
-					Date mpiDate = (Date)lpiValue;;
-					Date lpiDate = (Date)mpiValue;
-					if (lpiDate.compareTo(mpiDate) != 0) {
-						Map<String, Object> conflictingProperty = new HashMap<String, Object>();
-						conflictingProperty.put("lpi", lpiDate);
-						conflictingProperty.put("mpi", mpiDate);
-						conflictingProperties.put(property, conflictingProperty);
-					}
-				} else {
-					if (lpiValue != mpiValue) {
-						Map<String, Object> conflictingProperty = new HashMap<String, Object>();
-						conflictingProperty.put("lpi", lpiValue.toString());
-						conflictingProperty.put("mpi", mpiValue.toString());
-						conflictingProperties.put(property, conflictingProperty);
-					}
-				}
-			} catch (Exception e) {
-				log.warn(e.getMessage());
-			}
-		}
-		return conflictingProperties;
-	}
-	
-	public Map<String, String> getLpiMpiMergedIdentifiers(Person fromLpi, Person fromMpi) {
-		Map<String, String> lpiMpiMergedIdentifiers = new HashMap<String, String>();
-		if (fromLpi != null && fromMpi != null
-				&& fromLpi.getPersonIdentifierList() != null
-				&& fromMpi.getPersonIdentifierList() != null) {
-			if (!fromLpi.getPersonIdentifierList().isEmpty() && !fromMpi.getPersonIdentifierList().isEmpty()) {
-				for (PersonIdentifier lpiIdentifier : fromLpi.getPersonIdentifierList()) {
-					for (PersonIdentifier mpiIdentifier : fromMpi.getPersonIdentifierList()) {
-						if (lpiIdentifier.getIdentifierType().equals(mpiIdentifier.getIdentifierType())) {
-							if (!mpiIdentifier.getIdentifierType().equals(Type.cccLocalId)
-									&& !mpiIdentifier.getIdentifierType().equals(Type.cccUniqueId)) {
-								lpiMpiMergedIdentifiers.put(mpiIdentifier.getIdentifierType().toString(), mpiIdentifier.getIdentifier());
-							} else if (lpiIdentifier.getIdentifier().equalsIgnoreCase(mpiIdentifier.getIdentifier())) {
-								lpiMpiMergedIdentifiers.put(lpiIdentifier.getIdentifierType().toString(), lpiIdentifier.getIdentifier());
-							}
-						}
-					}
-				}
-			}
-		} else if (fromLpi != null && fromLpi.getPersonIdentifierList() != null && !fromLpi.getPersonIdentifierList().isEmpty()) {
-			for (PersonIdentifier lpiIdentifier : fromLpi.getPersonIdentifierList()) {
-				lpiMpiMergedIdentifiers.put(lpiIdentifier.getIdentifierType().toString(), lpiIdentifier.getIdentifier());
-			}
-		} else if (fromMpi != null && fromMpi.getPersonIdentifierList() != null && !fromMpi.getPersonIdentifierList().isEmpty()) {
-			for (PersonIdentifier mpiIdentifier : fromMpi.getPersonIdentifierList()) {
-				lpiMpiMergedIdentifiers.put(mpiIdentifier.getIdentifierType().toString(), mpiIdentifier.getIdentifier());
-			}
-		}
-		return lpiMpiMergedIdentifiers;
-	}
+    public Map<String, Map<String, Object>> getLpiMpiConflictingProperties(Person fromLpi, Person fromMpi) {
+        if (fromLpi == null && fromMpi == null) {
+            return Collections.emptyMap();
+        }
+        Map<String, Map<String, Object>> conflictingProperties = new HashMap<String, Map<String, Object>>();
+        for (String property : properties) {
+            String methodName = "get" + StringUtils.capitalize(property);
+            try {
+                Method method = Person.class.getMethod(methodName);
+                Object lpiValue = method.invoke(fromLpi);
+                Object mpiValue = method.invoke(fromMpi);
+                if (lpiValue == null || mpiValue == null) {
+                    continue;
+                }
+                if (lpiValue instanceof String || mpiValue instanceof String) {
+                    if (!StringUtils.equalsIgnoreCase(lpiValue.toString(), mpiValue.toString())) {
+                        Map<String, Object> conflictedProperty = new HashMap<String, Object>();
+                        conflictedProperty.put("lpi", lpiValue.toString());
+                        conflictedProperty.put("mpi", mpiValue.toString());
+                        conflictingProperties.put(property, conflictedProperty);
+                    }
+                } else if (lpiValue instanceof Date || mpiValue instanceof Date) {
+                    Date mpiDate = (Date) lpiValue;
+                    ;
+                    Date lpiDate = (Date) mpiValue;
+                    if (lpiDate.compareTo(mpiDate) != 0) {
+                        Map<String, Object> conflictingProperty = new HashMap<String, Object>();
+                        conflictingProperty.put("lpi", lpiDate);
+                        conflictingProperty.put("mpi", mpiDate);
+                        conflictingProperties.put(property, conflictingProperty);
+                    }
+                } else {
+                    if (lpiValue != mpiValue) {
+                        Map<String, Object> conflictingProperty = new HashMap<String, Object>();
+                        conflictingProperty.put("lpi", lpiValue.toString());
+                        conflictingProperty.put("mpi", mpiValue.toString());
+                        conflictingProperties.put(property, conflictingProperty);
+                    }
+                }
+            } catch (Exception e) {
+                log.warn(e.getMessage());
+            }
+        }
+        return conflictingProperties;
+    }
 
-	public Map<String, Map<String, String>> getConflictingIdentifiers(Person fromLpi, Person fromMpi) {
-		if ((fromLpi == null && fromMpi == null)
-				|| (fromLpi.getPersonIdentifierList().isEmpty() && fromMpi.getPersonIdentifierList().isEmpty())) {
-			return Collections.emptyMap();
-		}
-		Map<String, Map<String, String>> conflictingIdentifiers = new HashMap<String, Map<String,String>>();
-		for (PersonIdentifier lpiIdentifier : fromLpi.getPersonIdentifierList()) {
-			if (!lpiIdentifier.getIdentifierType().equals(Type.cccLocalId)
-					&& !lpiIdentifier.getIdentifierType().equals(Type.cccUniqueId)) {
-				continue;
-			}
-			for (PersonIdentifier mpiIdentifier : fromMpi.getPersonIdentifierList()) {
-				if (lpiIdentifier.getIdentifierType().equals(mpiIdentifier.getIdentifierType())
-						&& lpiIdentifier.getIdentifier() != mpiIdentifier.getIdentifier()) {
-					Map<String, String> conflictingIdentifierPair = new HashMap<String, String>();
-					conflictingIdentifierPair.put("lpi", lpiIdentifier.getIdentifier());
-					conflictingIdentifierPair.put("mpi", mpiIdentifier.getIdentifier());
-					conflictingIdentifiers.put(lpiIdentifier.getIdentifierType().toString(), conflictingIdentifierPair);
-				}
-			}
-		}
-		return conflictingIdentifiers;
-	}
+    public Map<String, String> getLpiMpiMergedIdentifiers(Person fromLpi, Person fromMpi) {
+        Map<String, String> lpiMpiMergedIdentifiers = new HashMap<String, String>();
+        if (fromLpi != null && fromMpi != null
+                && fromLpi.getPersonIdentifierList() != null
+                && fromMpi.getPersonIdentifierList() != null) {
+            if (!fromLpi.getPersonIdentifierList().isEmpty() && !fromMpi.getPersonIdentifierList().isEmpty()) {
+                for (PersonIdentifier lpiIdentifier : fromLpi.getPersonIdentifierList()) {
+                    for (PersonIdentifier mpiIdentifier : fromMpi.getPersonIdentifierList()) {
+                        if (lpiIdentifier.getIdentifierType().equals(mpiIdentifier.getIdentifierType())) {
+                            if (!mpiIdentifier.getIdentifierType().equals(Type.cccLocalId)
+                                    && !mpiIdentifier.getIdentifierType().equals(Type.cccUniqueId)) {
+                                lpiMpiMergedIdentifiers.put(mpiIdentifier.getIdentifierType().toString(), mpiIdentifier.getIdentifier());
+                            } else if (lpiIdentifier.getIdentifier().equalsIgnoreCase(mpiIdentifier.getIdentifier())) {
+                                lpiMpiMergedIdentifiers.put(lpiIdentifier.getIdentifierType().toString(), lpiIdentifier.getIdentifier());
+                            }
+                        }
+                    }
+                }
+            }
+        } else if (fromLpi != null && fromLpi.getPersonIdentifierList() != null && !fromLpi.getPersonIdentifierList().isEmpty()) {
+            for (PersonIdentifier lpiIdentifier : fromLpi.getPersonIdentifierList()) {
+                lpiMpiMergedIdentifiers.put(lpiIdentifier.getIdentifierType().toString(), lpiIdentifier.getIdentifier());
+            }
+        } else if (fromMpi != null && fromMpi.getPersonIdentifierList() != null && !fromMpi.getPersonIdentifierList().isEmpty()) {
+            for (PersonIdentifier mpiIdentifier : fromMpi.getPersonIdentifierList()) {
+                lpiMpiMergedIdentifiers.put(mpiIdentifier.getIdentifierType().toString(), mpiIdentifier.getIdentifier());
+            }
+        }
+        return lpiMpiMergedIdentifiers;
+    }
+
+    public Map<String, Map<String, String>> getConflictingIdentifiers(Person fromLpi, Person fromMpi) {
+        if (fromLpi == null || fromMpi == null) {
+            return Collections.emptyMap();
+        } else if (CollectionUtils.isEmpty(fromLpi.getPersonIdentifierList()) || CollectionUtils.isEmpty(fromMpi.getPersonIdentifierList())) {
+            //handle NPE thrown when accessing fields for a null fromLpi/fromMpi object
+            return Collections.emptyMap();
+        } else {
+            Map<String, Map<String, String>> conflictingIdentifiers = new HashMap<String, Map<String, String>>();
+            for (PersonIdentifier lpiIdentifier : fromLpi.getPersonIdentifierList()) {
+                if (!lpiIdentifier.getIdentifierType().equals(Type.cccLocalId)
+                        && !lpiIdentifier.getIdentifierType().equals(Type.cccUniqueId)) {
+                    continue;
+                }
+                for (PersonIdentifier mpiIdentifier : fromMpi.getPersonIdentifierList()) {
+                    if (lpiIdentifier.getIdentifierType().equals(mpiIdentifier.getIdentifierType())
+                            && lpiIdentifier.getIdentifier() != mpiIdentifier.getIdentifier()) {
+                        Map<String, String> conflictingIdentifierPair = new HashMap<String, String>();
+                        conflictingIdentifierPair.put("lpi", lpiIdentifier.getIdentifier());
+                        conflictingIdentifierPair.put("mpi", mpiIdentifier.getIdentifier());
+                        conflictingIdentifiers.put(lpiIdentifier.getIdentifierType().toString(), conflictingIdentifierPair);
+                    }
+                }
+            }
+            return conflictingIdentifiers;
+
+        }
+
+
+    }
 }

--- a/api/src/main/java/org/openmrs/module/kenyareg/api/utils/OpenmrsPersonToOecPersonConverter.java
+++ b/api/src/main/java/org/openmrs/module/kenyareg/api/utils/OpenmrsPersonToOecPersonConverter.java
@@ -1,6 +1,7 @@
 package org.openmrs.module.kenyareg.api.utils;
 
 import ke.go.moh.oec.PersonIdentifier;
+import org.apache.commons.lang3.ArrayUtils;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
 import org.openmrs.Person;
@@ -18,9 +19,9 @@ public class OpenmrsPersonToOecPersonConverter {
     }
 
     public static ke.go.moh.oec.Person convert(Person openmrsPerson) {
-        ke.go.moh.oec.Person oecPerson=new ke.go.moh.oec.Person();
+        ke.go.moh.oec.Person oecPerson = new ke.go.moh.oec.Person();
         oecPerson.setPersonGuid(openmrsPerson.getUuid());
-        oecPerson.setSex(openmrsPerson.getGender().equals("M")? ke.go.moh.oec.Person.Sex.M: ke.go.moh.oec.Person.Sex.F);
+        oecPerson.setSex(openmrsPerson.getGender().equals("M") ? ke.go.moh.oec.Person.Sex.M : ke.go.moh.oec.Person.Sex.F);
         oecPerson.setBirthdate(openmrsPerson.getBirthdate());
         oecPerson.setFirstName(openmrsPerson.getGivenName());
         oecPerson.setDeathdate(openmrsPerson.getDeathDate());
@@ -29,44 +30,56 @@ public class OpenmrsPersonToOecPersonConverter {
         oecPerson.setMiddleName(personName.getMiddleName());
         oecPerson.setLastName(personName.getFamilyName());
 
-        Patient openmrsPatient= (Patient) openmrsPerson;
+        Patient openmrsPatient = (Patient) openmrsPerson;
         Set<PatientIdentifier> identifiers = openmrsPatient.getIdentifiers();
         oecPerson = mergePatientIdentifiers(oecPerson, identifiers);
         return oecPerson;
     }
 
-    private static ke.go.moh.oec.Person mergePatientIdentifiers(ke.go.moh.oec.Person person,  Set<PatientIdentifier> identifiers) {
+    private static ke.go.moh.oec.Person mergePatientIdentifiers(ke.go.moh.oec.Person person, Set<PatientIdentifier> identifiers) {
         assert person != null;
         assert identifiers != null;
-
-        for (PatientIdentifier identifier: identifiers) {
-            if (matchesIdentifierInOec(identifier.getIdentifierType().toString())) {
-                updateOecIdentifier(person, identifier.getIdentifier(), identifier.getIdentifierType().toString());
+        for (PatientIdentifier identifier : identifiers) {
+            String identifierType = identifier.getIdentifierType().getName();
+            if (matchesIdentifierInOec(identifierType)) {
+                String matchedOecIdentifierType = getMatchedOecIdentifierType(identifierType);
+                updateOecIdentifier(person, identifier.getIdentifier(), matchedOecIdentifierType);
             }
         }
         return person;
     }
 
-    private static boolean matchesIdentifierInOec(String identifierName) {
+    private static boolean matchesIdentifierInOec(String identifierType) {
         PersonIdentifier.Type[] availableOecIdenitfierTypes = PersonIdentifier.Type.values();
-
-        for (PersonIdentifier.Type identifierType : availableOecIdenitfierTypes) {
-            if (identifierType.name().equalsIgnoreCase(identifierName)) {
-                return true;
-            }
-        }
-        return false;
+        String matchedOecIdentifierType = getMatchedOecIdentifierType(identifierType);
+        return ArrayUtils.contains(availableOecIdenitfierTypes, matchedOecIdentifierType);
     }
 
-    private static void updateOecIdentifier(ke.go.moh.oec.Person person, String identifier, String identifierType) {
-        PersonIdentifier.Type patientIdentifierType = PersonIdentifier.Type.valueOf(identifierType);
-        PersonIdentifier personIdentifier=new PersonIdentifier();
+
+    private static String getMatchedOecIdentifierType(String identifierType){
+        String matched=null;
+        for (OpenmrsTypeConverter s : OpenmrsTypeConverter.values()) {
+            if (s.getTypeString().equalsIgnoreCase(identifierType)) {
+                /*
+                An identifier type has been found in openmrs that matches a possible oec identifier type
+                This is only true as long as Identifier Strings do not change as they have been hard coded in @link OpenmrsTypeConverter
+                 */
+                System.out.printf("Found a match at : %s == %s for identifier type : %s \n", s.getTypeString(), identifierType,s.name());
+                matched = s.name();
+            }
+        }
+        return matched;
+
+    }
+
+    private static void updateOecIdentifier(ke.go.moh.oec.Person person, String identifier, String matchedOecIdentifierType) {
+        PersonIdentifier.Type patientIdentifierType = PersonIdentifier.Type.valueOf(matchedOecIdentifierType);
+        PersonIdentifier personIdentifier = new PersonIdentifier();
         personIdentifier.setIdentifierType(patientIdentifierType);
         personIdentifier.setIdentifier(identifier);
-
         boolean identifierSet = false;
         for (PersonIdentifier existingIdentifier : person.getPersonIdentifierList()) {
-            if (existingIdentifier.getIdentifierType().name().equalsIgnoreCase(identifierType)) {
+            if (existingIdentifier.getIdentifierType().name().equalsIgnoreCase(matchedOecIdentifierType)) {
                 existingIdentifier.setIdentifier(identifier);
                 identifierSet = true;
                 break;
@@ -74,6 +87,30 @@ public class OpenmrsPersonToOecPersonConverter {
         }
         if (!identifierSet) {
             person.getPersonIdentifierList().add(personIdentifier);
+        }
+    }
+
+    public enum OpenmrsTypeConverter {
+        openMRSIdentificationNumber("OpenMRS Identification Number"),
+        oldIdentificationNumber("Old Identification Number"),
+        openMRSID("OpenMRS ID"),
+        nationalID("National ID"),
+        heiIdNumber("HEI ID Number"),
+        districtRegistrationNumber("District Registration Number"),
+        patientRegistryId("Patient Redistry ID"),
+        masterPatientRegistryId("Master Patient Registry ID"),
+        cccUniqueId("Unique Patient Number"),
+        cccLocalId("Patient Clinic Number"),
+        kisumuHdssId("Kisumu HDSS ID");
+
+        private final String typeString;
+
+        public String getTypeString() {
+            return typeString;
+        }
+
+        private OpenmrsTypeConverter(String typeString) {
+            this.typeString = typeString;
         }
     }
 


### PR DESCRIPTION
handle NPE thrown when both lpi/mpi results are rejected causing getPersonIdentifierList() to be called on null collections
