### PR TITLE
map oec to openmrs identifier types for merging functionality

### DIFF
--- a/api/src/main/java/org/openmrs/module/kenyareg/api/utils/OpenmrsPersonToOecPersonConverter.java
+++ b/api/src/main/java/org/openmrs/module/kenyareg/api/utils/OpenmrsPersonToOecPersonConverter.java
@@ -58,11 +58,11 @@ public class OpenmrsPersonToOecPersonConverter {
 
     private static String getMatchedOecIdentifierType(String identifierType){
         String matched=null;
-        for (OpenmrsTypeConverter s : OpenmrsTypeConverter.values()) {
+        for (OpenmrsIdentifierTypeConverter s : OpenmrsIdentifierTypeConverter.values()) {
             if (s.getTypeString().equalsIgnoreCase(identifierType)) {
                 /*
                 An identifier type has been found in openmrs that matches a possible oec identifier type
-                This is only true as long as Identifier Strings do not change as they have been hard coded in @link OpenmrsTypeConverter
+                This is only true as long as Identifier Strings do not change as they have been hard coded in @link OpenmrsIdentifierTypeConverter
                  */
                 System.out.printf("Found a match at : %s == %s for identifier type : %s \n", s.getTypeString(), identifierType,s.name());
                 matched = s.name();
@@ -90,14 +90,14 @@ public class OpenmrsPersonToOecPersonConverter {
         }
     }
 
-    public enum OpenmrsTypeConverter {
+    public enum OpenmrsIdentifierTypeConverter {
         openMRSIdentificationNumber("OpenMRS Identification Number"),
         oldIdentificationNumber("Old Identification Number"),
         openMRSID("OpenMRS ID"),
         nationalID("National ID"),
         heiIdNumber("HEI ID Number"),
         districtRegistrationNumber("District Registration Number"),
-        patientRegistryId("Patient Redistry ID"),
+        patientRegistryId("Patient Registry ID"),
         masterPatientRegistryId("Master Patient Registry ID"),
         cccUniqueId("Unique Patient Number"),
         cccLocalId("Patient Clinic Number"),
@@ -109,7 +109,7 @@ public class OpenmrsPersonToOecPersonConverter {
             return typeString;
         }
 
-        private OpenmrsTypeConverter(String typeString) {
+        private OpenmrsIdentifierTypeConverter(String typeString) {
             this.typeString = typeString;
         }
     }

--- a/api/src/test/java/org/openmrs/module/kenyareg/api/PersonMergeServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/kenyareg/api/PersonMergeServiceTest.java
@@ -1,14 +1,9 @@
 package org.openmrs.module.kenyareg.api;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
+import ke.go.moh.oec.Person;
+import ke.go.moh.oec.Person.Sex;
+import ke.go.moh.oec.PersonIdentifier;
+import ke.go.moh.oec.PersonIdentifier.Type;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -24,10 +19,9 @@ import org.openmrs.PatientIdentifierType;
 import org.openmrs.PersonName;
 import org.openmrs.api.PatientService;
 
-import ke.go.moh.oec.Person;
-import ke.go.moh.oec.Person.Sex;
-import ke.go.moh.oec.PersonIdentifier;
-import ke.go.moh.oec.PersonIdentifier.Type;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PersonMergeServiceTest {
@@ -190,13 +184,13 @@ public class PersonMergeServiceTest {
 
 	private PatientIdentifierType getCccLocalIdentifier() {
 		PatientIdentifierType cccLocalId = new PatientIdentifierType();
-		cccLocalId.setName(Type.cccLocalId.toString());
+		cccLocalId.setName("Patient Clinic Number");
 		return cccLocalId;
 	}
 
 	private PatientIdentifierType getCccUniqueIdentifier() {
 		PatientIdentifierType cccUniqueId = new PatientIdentifierType();
-		cccUniqueId.setName(Type.cccUniqueId.toString());
+		cccUniqueId.setName("Unique Patient Number");
 		return cccUniqueId;
 	}
 


### PR DESCRIPTION
map oec to openmrs identifier types for merging functionality.
NB: NUPI(KEMRI/KISUMU HDSS AREA) not having a clear match in openmrs - need to create another openmrs identifier type?
